### PR TITLE
fix(admin): prevent submitting null program type in ProgramForm

### DIFF
--- a/src/components/admin/ProgramForm.tsx
+++ b/src/components/admin/ProgramForm.tsx
@@ -175,22 +175,27 @@ export default function ProgramForm({ program, onSuccess, onCancel }: ProgramFor
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div>
                 <Label htmlFor="id_universidad">University *</Label>
-                <Select
-                  key={`univ-${universities.length}`}
-                  value={formData.id_universidad?.toString() || ''}
-                  onValueChange={(value) => setFormData({ ...formData, id_universidad: parseInt(value) })}
-                >
-                  <SelectTrigger>
-                    <SelectValue placeholder="Select university" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {universities.map((uni) => (
-                      <SelectItem key={uni.id_universidad} value={uni.id_universidad.toString()}>
-                        {uni.universidad}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                {universities.length === 0 ? (
+                  <div className="flex h-10 items-center rounded-md border border-input px-3 text-sm text-muted-foreground">
+                    Loading universities...
+                  </div>
+                ) : (
+                  <Select
+                    value={formData.id_universidad > 0 ? formData.id_universidad.toString() : ''}
+                    onValueChange={(value) => setFormData({ ...formData, id_universidad: parseInt(value) })}
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="Select university" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {universities.map((uni) => (
+                        <SelectItem key={uni.id_universidad} value={uni.id_universidad.toString()}>
+                          {uni.universidad}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                )}
               </div>
 
               <div>


### PR DESCRIPTION
## Summary
- Added client-side validation in `ProgramForm` to reject submission when `id_universidad` or `id_tipo_programa` is 0/null
- Added a fallback `SelectItem` so the current program type is always visible in the dropdown even if it's not in the loaded list
- Fixed `catch (err: any)` → `catch (err: unknown)` to satisfy strict TypeScript / ESLint rules

## Context
Part of the fix for issue futurappedu/futurapp_api#51 — `PUT /v1/admin/programs/:id` was returning 500 because the form was submitting `id_tipo_programa: null`. The Select component showed an empty value when the program's current type ID didn't match any option in the loaded list, and there was no pre-submit validation to catch this.

## Test Plan
- [ ] Open the Edit Program modal for a program whose type is in the dropdown — verify type is pre-selected
- [ ] Open the Edit Program modal for a program whose type is NOT in the dropdown — verify the current type label is still shown
- [ ] Try to submit without selecting a university or program type — verify inline error message appears
- [ ] Normal update with all required fields — verify saves successfully

## Checklist
- [x] `npm run lint` passes
- [x] `npm run build` succeeds
- [x] Self-review completed